### PR TITLE
Allow decimal inputs for hypotenuse calculation

### DIFF
--- a/python-village/INI2-variables-and-some-arithmetic/solution.py
+++ b/python-village/INI2-variables-and-some-arithmetic/solution.py
@@ -1,16 +1,38 @@
 # solution.py
 def hypotenuse_square(a, b):
-    """
-    Calculate the square of the hypotenuse of a right triangle given the lengths of the other two sides.
+    """Return the square of the hypotenuse given the other side lengths.
 
-    :param a: Length of one side
-    :param b: Length of the other side
-    :return: Square of the hypotenuse
+    The function accepts any real numbers for ``a`` and ``b`` and raises a
+    ``ValueError`` if either value is negative.  This mirrors the mathematical
+    requirement that side lengths of a triangle are non‑negative.  Using floats
+    here allows the function to be used with measurements that aren't whole
+    numbers (the previous implementation forced integer input via ``map(int)``,
+    which raised ``ValueError`` on valid decimal input).
+
+    Parameters
+    ----------
+    a : float
+        Length of one side of the triangle.
+    b : float
+        Length of the other side of the triangle.
+
+    Returns
+    -------
+    float
+        The square of the hypotenuse.
     """
-    return a**2 + b**2
+
+    if a < 0 or b < 0:
+        raise ValueError("Side lengths must be non-negative")
+
+    return a ** 2 + b ** 2
 
 if __name__ == "__main__":
-    # Read two intergers from standard input
-    a, b = map(int, input().split())    
-    #compute and priint a^2 + b^2
-    print(hypotenuse_square(a, b))
+    # Read two numbers from standard input.  ``float`` is used instead of
+    # ``int`` so that decimal side lengths are handled gracefully.
+    a, b = map(float, input().split())
+
+    # Compute and print a^2 + b^2.  If the result is mathematically an
+    # integer, drop the trailing ``.0`` for a cleaner output.
+    result = hypotenuse_square(a, b)
+    print(int(result) if result.is_integer() else result)


### PR DESCRIPTION
## Summary
- allow `hypotenuse_square` to accept float inputs and validate non-negative sides
- parse floats from stdin and format output cleanly

## Testing
- `python python-village/INI2-variables-and-some-arithmetic/solution.py <<'EOF'
3.5 4.2
EOF`
- `python python-village/INI2-variables-and-some-arithmetic/solution.py <<'EOF'
-3 4
EOF`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68941672363883219191c3beb9e554d0